### PR TITLE
Update diarization.py with new pyannote API for Pipeline.from_pretrained

### DIFF
--- a/src/whisper_ctranslate2/diarization.py
+++ b/src/whisper_ctranslate2/diarization.py
@@ -35,7 +35,7 @@ class Diarization:
         model_name = "pyannote/speaker-diarization-3.1"
         device = torch.device(self.device)
         model_handle = Pipeline.from_pretrained(
-            model_name, use_auth_token=self.use_auth_token
+            model_name, token=self.use_auth_token
         )
         if model_handle is None:
             raise ValueError(


### PR DESCRIPTION
Pyannote.audio Pipeline.from_pretrained has been updated, and the current image is built from an updated version.

See https://github.com/pyannote/pyannote-audio/blob/f8efe0ac5ceb82dad7c73551607b11b6b7be6e68/src/pyannote/audio/core/pipeline.py#L140

for reference.

Tomas, I made this to make the process faster for you, let me know if it helps or if you'd like it to be a different format in the future :)